### PR TITLE
[obex] Remove qt5-qtsysteminfo usage. Fixes JB#56949

### DIFF
--- a/rpm/obex-capability.spec
+++ b/rpm/obex-capability.spec
@@ -6,8 +6,8 @@ License: GPLv2
 Source: %{name}-%{version}.tar.gz
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5Xml)
-BuildRequires: pkgconfig(Qt5SystemInfo)
-
+BuildRequires: pkgconfig(ssu)
+BuildRequires: pkgconfig(systemsettings) >= 0.6.0
 
 %description
 %{summary}.

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,8 @@ TARGET = obex-capability
 QT += xml
 QT -= gui
 CONFIG += link_pkgconfig
-PKGCONFIG += Qt5SystemInfo
+PKGCONFIG += ssu
+PKGCONFIG += systemsettings
 
 HEADERS = obex-capability.h
 


### PR DESCRIPTION
All of qt5-qtsystems is deprecated and should not be used.

Use DeviceInfo class from nemo-qml-plugin-systemsettings instead of
QDeviceInfo from qt5-qtsysteminfo.

Drop support for optional obex attributes requiring use of QNetworkInfo.

Remove unused code referring to QStorageInfo.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>